### PR TITLE
added note/warning about mem management

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ add_text(xs3, "California")
 set_attributes(xs3; tag="CA", cap="Sacramento")
 ```
 
-Please note that when you create XML documents and elements directly you need to take care not to leak memory; memory management in the underlying libxml2 library is complex and LightXML currently does not integrate well with Julia's garbage collection system. You can call free on an XMLDocument but if you are directly creating XMLElement's there is not yet a corresponding free function to call.
+**Note:** When you create XML documents and elements directly you need to take care not to leak memory; memory management in the underlying libxml2 library is complex and LightXML currently does not integrate well with Julia's garbage collection system. You can call ``free`` on an XMLDocument but if you are directly creating XMLElement's there is not yet a corresponding ``free`` function to call.
 
 #### Export an XML file
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ add_text(xs3, "California")
 set_attributes(xs3; tag="CA", cap="Sacramento")
 ```
 
+Please note that when you create XML documents and elements directly you need to take care not to leak memory; memory management in the underlying libxml2 library is complex and LightXML currently does not integrate well with Julia's garbage collection system. You can call free on an XMLDocument but if you are directly creating XMLElement's there is not yet a corresponding free function to call.
+
 #### Export an XML file
 
 With this package, you can easily export an XML file to a string or a file, or show it on the console, as


### PR DESCRIPTION
If you create a large number of XMLElement's programmatically you can create memory leaks since the underlying C structures in libxml2 will not be automatically freed. This at least warns/notes users of this fact until it can be fixed. This is in reference to the issues:

https://github.com/JuliaLang/LightXML.jl/issues/16#issuecomment-71758263

and:

https://github.com/JuliaLang/LightXML.jl/issues/17

