### PR TITLE
set finalizer for XMLDocument by default

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -43,7 +43,9 @@ type XMLDocument
         @assert s.nodetype == XML_DOCUMENT_NODE
         @assert s.doc == ptr
 
-        new(ptr, s)
+        xmldoc = new(ptr, s)
+        finalizer(xmldoc, free)
+        xmldoc
     end
 
     function XMLDocument()


### PR DESCRIPTION
I propose most new users would rather prefer the finalizer is set by default. This does not solve the issue if people create their own XMLElement's but if they have a top-level XMLDocument the memory of it and all its sub-children will be gc'd once we no longer use the document.