### PR TITLE
Add free(::XMLNode) and free(::XMLElement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ add_text(xs3, "California")
 set_attributes(xs3; tag="CA", cap="Sacramento")
 ```
 
-**Note:** When you create XML documents and elements directly you need to take care not to leak memory; memory management in the underlying libxml2 library is complex and LightXML currently does not integrate well with Julia's garbage collection system. You can call ``free`` on an XMLDocument but if you are directly creating XMLElement's there is not yet a corresponding ``free`` function to call.
+**Note:** When you create XML documents and elements directly you need to take care not to leak memory; memory management in the underlying libxml2 library is complex and LightXML currently does not integrate well with Julia's garbage collection system. You can call ``free`` on an XMLDocument, XMLNode or XMLElement but you must take care not to reference any child elements after they have been manually freed.
 
 #### Export an XML file
 
@@ -242,6 +242,11 @@ get_elements_by_tagname(e, name)  # a list of all child elements of e with
 
 string(e)               # format an XML element into a string
 show(io, e)             # output formatted XML element
+
+unlink(x)               # remove a node or element from its current context
+                        # (unlink does not free the memory for the node/element)
+free(xdoc)              # release memory for a document and all its children
+free(x)                 # release memory for a node/element and all its children
 ```
 
 ##### Functions to create an XML document

--- a/src/LightXML.jl
+++ b/src/LightXML.jl
@@ -14,7 +14,7 @@ module LightXML
     child_elements, find_element, get_elements_by_tagname,
 
     new_element, add_child, new_child, new_textnode, add_text, add_cdata,
-    set_attribute, set_attributes,
+    set_attribute, set_attributes, unlink,
 
     # document
     XMLDocument, version, encoding, compression, standalone, root,

--- a/src/clib.jl
+++ b/src/clib.jl
@@ -53,6 +53,7 @@ _xcopystr(p::Xstr) = (r = bytestring(p); _xmlfree(p); r)
 @lx2func xmlNewCDataBlock
 @lx2func xmlSetProp
 @lx2func xmlFreeNode
+@lx2func xmlUnlinkNode
 
 # functions for documents
 

--- a/src/clib.jl
+++ b/src/clib.jl
@@ -52,6 +52,7 @@ _xcopystr(p::Xstr) = (r = bytestring(p); _xmlfree(p); r)
 @lx2func xmlNewText
 @lx2func xmlNewCDataBlock
 @lx2func xmlSetProp
+@lx2func xmlFreeNode
 
 # functions for documents
 

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -146,8 +146,12 @@ has_children(nd::XMLNode) = (nd._struct.children != nullptr)
 is_blanknode(nd::XMLNode) = bool(ccall(xmlIsBlankNode, Cint, (Xptr,), nd.ptr))
 
 function free(nd::XMLNode)
-    ccall(xmlFreeNode, Void, (Ptr{Void},), nd.ptr)
+    ccall(xmlFreeNode, Void, (Xptr,), nd.ptr)
     nd.ptr = nullptr
+end
+
+function unlink(nd::XMLNode)
+    ccall(xmlUnlinkNode, Void, (Xptr,), nd.ptr)
 end
 
 # iteration over children
@@ -212,6 +216,7 @@ Base.string(x::XMLElement) = string(x.node)
 Base.show(io::IO, x::XMLElement) = show(io, x.node)
 
 free(x::XMLElement) = free(x.node)
+unlink(x::XMLElement) = unlink(x.node)
 
 # attribute access
 

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -145,6 +145,10 @@ has_children(nd::XMLNode) = (nd._struct.children != nullptr)
 # whether it is a white-space only text node
 is_blanknode(nd::XMLNode) = bool(ccall(xmlIsBlankNode, Cint, (Xptr,), nd.ptr))
 
+function free(nd::XMLNode)
+    ccall(xmlFreeNode, Void, (Ptr{Void},), nd.ptr)
+    nd.ptr = nullptr
+end
 
 # iteration over children
 
@@ -206,6 +210,8 @@ content(x::XMLElement) = content(x.node)
 
 Base.string(x::XMLElement) = string(x.node)
 Base.show(io::IO, x::XMLElement) = show(io, x.node)
+
+free(x::XMLElement) = free(x.node)
 
 # attribute access
 


### PR DESCRIPTION
Adds a manual solution to #17 - how to deal with finalizers, gc, and whether or not we need reference counting for child elements is still an open question but I don't think there's any harm in adding a manual free method to the exposed API here.

cc @robertfeldt you had done something similar in your branch. I've made it work for `XMLNode` as well, because why not.