### PR TITLE
Fixes for Julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3-
 BinDeps
+Compat
 @windows WinRPM

--- a/src/LightXML.jl
+++ b/src/LightXML.jl
@@ -20,7 +20,7 @@ module LightXML
     XMLDocument, version, encoding, compression, standalone, root,
     parse_file, parse_string, save_file, set_root, create_root
 
-
+    using Compat
     include("clib.jl")
     include("errors.jl")
 

--- a/src/clib.jl
+++ b/src/clib.jl
@@ -1,11 +1,11 @@
 # C functions in the library
 
-@unix_only const libxml2 = dlopen("libxml2", RTLD_GLOBAL)
-@windows_only const libxml2 = dlopen(Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libxml2-2"))
+@unix_only const libxml2 = Libdl.dlopen("libxml2", Libdl.RTLD_GLOBAL)
+@windows_only const libxml2 = Libdl.dlopen(Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libxml2-2"))
 
 macro lx2func(fname)  # the macro to get functions from libxml2
     quote
-        $(esc(fname)) = dlsym( libxml2, ($(string(fname))) )
+        $(esc(fname)) = Libdl.dlsym( libxml2, ($(string(fname))) )
     end
 end
 

--- a/src/document.jl
+++ b/src/document.jl
@@ -55,8 +55,8 @@ end
 
 version(xdoc::XMLDocument) = bytestring(xdoc._struct.version)
 encoding(xdoc::XMLDocument) = bytestring(xdoc._struct.encoding)
-compression(xdoc::XMLDocument) = int(xdoc._struct.compression)
-standalone(xdoc::XMLDocument) = int(xdoc._struct.standalone)
+compression(xdoc::XMLDocument) = @compat Int(xdoc._struct.compression)
+standalone(xdoc::XMLDocument) = @compat Int(xdoc._struct.standalone)
 
 function root(xdoc::XMLDocument)
     pr = ccall(xmlDocGetRootElement, Ptr{Void}, (Ptr{Void},), xdoc.ptr)

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -143,7 +143,7 @@ nodetype(nd::XMLNode) = nd._struct.nodetype
 has_children(nd::XMLNode) = (nd._struct.children != nullptr)
 
 # whether it is a white-space only text node
-is_blanknode(nd::XMLNode) = bool(ccall(xmlIsBlankNode, Cint, (Xptr,), nd.ptr))
+is_blanknode(nd::XMLNode) = @compat Bool(ccall(xmlIsBlankNode, Cint, (Xptr,), nd.ptr))
 
 function free(nd::XMLNode)
     ccall(xmlFreeNode, Void, (Xptr,), nd.ptr)


### PR DESCRIPTION
Would appreciate anyone looking over this who might have time, mostly straightforward ~~though I'm not 100% certain about the `ccall` `pointer` additions which got rid of `WARNING: convert(::Type{Ptr}, ::Array{UInt8,1}) methods should be converted to be methods of unsafe_convert`~~