### PR TITLE
do not emit a newline when showing nodes/elements

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -123,4 +123,4 @@ function Base.string(xdoc::XMLDocument; encoding::AbstractString="utf-8")
     _xcopystr(buf_out[1])
 end
 
-Base.show(io::IO, xdoc::XMLDocument) = println(io, string(xdoc))
+Base.show(io::IO, xdoc::XMLDocument) = print(io, string(xdoc))

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -184,7 +184,7 @@ function Base.string(nd::XMLNode)
     return r
 end
 
-Base.show(io::IO, nd::XMLNode) = println(io, string(nd))
+Base.show(io::IO, nd::XMLNode) = print(io, string(nd))
 
 
 #######################################


### PR DESCRIPTION
I think emitting a newline when the `show` method is called is not a standard way in Julia.