### PR TITLE
Add Base.getindex() support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,76 @@ v = ad["category"]  # v <-- "COOKING"
 **Note:** The functions ``child_nodes``, ``child_elements``, and ``attributes`` return light weight iterators -- so that one can use them with for-loop. To get an array of all items, one may use the ``collect`` function provided by Julia.
 
 
+#### XML as an Indexable Collection
+
+Extract the content of a single tag:
+
+```julia
+xml = parse_string("""
+<CreateQueueResponse>
+    <CreateQueueResult>
+        <QueueUrl>http://queue.amazonaws.com/123456789012/testQueue</QueueUrl>
+    </CreateQueueResult>
+</CreateQueueResponse>
+""")
+
+@test xml["CreateQueueResult"]["QueueUrl"] ==
+      "http://queue.amazonaws.com/123456789012/testQueue"
+```
+
+Extract an attribute from a tag:
+
+```julia
+xml = parse_string("""
+<bookstore>
+  <book category="COOKING" tag="first"/>
+<bookstore>
+
+@test xml["bookstore"]["book"][:category] == "COOKING"
+```
+
+
+Extract a list of tag content:
+
+```julia
+xml = parse_string("""
+<ListAllMyBucketsResult>
+  <Buckets>
+    <Bucket><Name>quotes</Name><CreationDate>2006-02-03T16:45:09.000Z</CreationDate></Bucket>
+    <Bucket><Name>samples</Name><CreationDate>2006-02-03T16:41:58.000Z</CreationDate></Bucket>
+  </Buckets>
+</ListAllMyBucketsResult>
+""")
+
+@test [b["Name"] in xml["Buckets"]["Bucket"]] == ["quotes", "samples"]
+```
+
+Extract a dictionary of tag content:
+
+```julia
+
+xml = parse_string("""
+<GetQueueAttributesResponse>
+  <GetQueueAttributesResult>
+    <Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute>
+    <Attribute><Name>CreatedTimestamp</Name><Value>1286771522</Value></Attribute>
+    <Attribute><Name>MaximumMessageSize</Name><Value>8192</Value></Attribute>
+    <Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute>
+  </GetQueueAttributesResult>
+</GetQueueAttributesResponse>
+""")
+
+d = [a["Name"] => a["Value"] for a in xml["GetQueueAttributesResult"]["Attribute"]]
+
+Dict with 4 entries:
+  "MessageRetentionPeriod" => "345600"
+  "MaximumMessageSize"     => "8192"
+  "VisibilityTimeout"      => "30"
+  "CreatedTimestamp"       => "1286771522"
+```
+
+
+
 #### Create an XML Document
 
 This package allows you to construct an XML document programmatically. For example, to create an XML document as

--- a/src/LightXML.jl
+++ b/src/LightXML.jl
@@ -44,5 +44,6 @@ include("utils.jl")
 include("nodes.jl")
 include("document.jl")
 include("cdata.jl")
+include("getindex.jl")
 
 end

--- a/src/document.jl
+++ b/src/document.jl
@@ -54,7 +54,13 @@ type XMLDocument
 end
 
 version(xdoc::XMLDocument) = bytestring(xdoc._struct.version)
-encoding(xdoc::XMLDocument) = bytestring(xdoc._struct.encoding)
+function encoding(xdoc::XMLDocument)
+    if xdoc._struct.encoding == C_NULL
+        nothing
+    else
+        bytestring(xdoc._struct.encoding)
+    end
+end
 compression(xdoc::XMLDocument) = @compat Int(xdoc._struct.compression)
 standalone(xdoc::XMLDocument) = @compat Int(xdoc._struct.standalone)
 

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -1,5 +1,6 @@
 # Indexable Collection support
 
+export xml_dict, dict_xml
 
 function Base.getindex(x::XMLElement, tag::AbstractString)
     l = get_elements_by_tagname(x, tag)
@@ -25,3 +26,167 @@ Base.haskey(x::XMLElement, tag) = getindex(x, tag) != nothing
 Base.getindex(x::XMLDocument, tag) = getindex(root(x), tag)
 Base.haskey(x::XMLDocument, tag) = haskey(root(x), tag)
 Base.get(x::XMLDocument, tag, default) = get(root(x), tag, default)
+
+
+# Convert XMLDocument to OrderedDict...
+
+using DataStructures
+
+function xml_dict(x::AbstractString, dict_type::Type=OrderedDict; options...)
+    xml_dict(parse_string(x), dict_type; options...)
+end
+
+function xml_dict(x::XMLDocument, dict_type::Type=OrderedDict; options...)
+    r = dict_type()
+    r[:version] = version(x)
+    if encoding(x) != nothing
+        r[:encoding] = encoding(x)
+    end
+    r[name(root(x))] = xml_dict(root(x), dict_type; options...)
+    r
+end
+
+
+is_text(x::XMLNode) = is_textnode(x) || is_cdatanode(x)
+Base.isempty(x::XMLNode) = isspace(content(x))
+has_text(x::XMLNode) = is_text(x) && !isempty(x)
+
+
+function xml_dict(x::XMLElement, dict_type::Type; strip_text=false)
+
+    # Copy element attributes into dict...
+    r = dict_type()
+    for a in attributes(x)
+        r[symbol(name(a))] = value(a)
+    end
+
+    # Check for non-empty text nodes under this element...
+    element_has_text = any(has_text, child_nodes(x))
+    if element_has_text
+        r[:text] = Any[]
+    end
+
+    for c in child_nodes(x)
+
+        if is_elementnode(c)
+
+            # Get name and sub-dict for sub-element...
+            c = XMLElement(c)
+            n = name(c)
+            v = xml_dict(c,dict_type;strip_text=strip_text)
+
+            if haskey(r, :text)
+
+                # If this is a text element, embed sub-dict in text vector...
+                # "The <b>bold</b> tag" == ["The", Dict("b" => "bold"), "tag"]
+                push!(r[:text], dict_type(n => v))
+
+            elseif haskey(r, n)
+
+                # Collect sub-elements with same tag into a vector...
+                # "<item>foo</item><item>bar</item>" == "item" => ["foo", "bar"]
+                a = isa(r[n], Array) ? r[n] : [r[n]]
+                push!(a, v)
+                r[n] = a
+            else
+                r[n] = v
+            end
+
+        elseif is_text(c) && haskey(r, :text)
+            push!(r[:text], content(c))
+        end
+    end
+
+    # Collapse text-only elements...
+    if haskey(r, :text)
+        if length(r[:text]) == 1
+            r[:text] = r[:text][1]
+            if strip_text
+                r[:text] = strip(r[:text])
+            end
+        end
+        if length(r) == 1
+            r = r[:text]
+        end
+    end
+
+    return r
+end
+
+
+# Convert Dict to XMLDocument.
+# dict_xml(xml_dict(xml_string)) == xml_string
+
+function dict_xml(root::Associative)
+    xml = "<?xml"
+    for (n,v) in root
+        if isa(n, Symbol)
+            xml *= " $n=\"$v\""
+        end
+    end
+    xml *= "?>\n"
+    xml *=_dict_xml(root)
+end
+
+
+function _dict_xml(node::Associative)
+
+    xml = ""
+
+    for (n,v) in node
+
+        # Ignore attributes of parent element...
+        if isa(n, Symbol) && n != :text
+            continue
+        end
+        # Expand homogeneous array of elements...
+        if (typeof(v) <: AbstractArray
+        &&  all(i -> typeof(i) == typeof(v[1]), v))
+            for i in v
+                xml *= _dict_xml(Dict(n=>i))
+            end
+            continue
+        end
+
+        # Emmit <tag attrs...> for non text nodes...
+        if n != :text
+            xml *= "<$n"
+            if typeof(v) <: Associative
+                for (an,av) in v
+                    if isa(an, Symbol) && an != :text
+                        xml *= " $an=\"$av\""
+                    end
+                end
+            end
+            xml *= ">"
+        end
+
+        if typeof(v) <: Associative  
+
+            # Recursive call for sub-dict...
+            xml *= _dict_xml(v)
+
+        elseif typeof(v) <: AbstractArray
+
+            # Expand heterogeneous array...
+            for i in v
+                if typeof(i) <: AbstractString
+                    xml *= i
+                else
+                    xml *= _dict_xml(i)
+                end
+            end
+        else
+
+            # Just plain text...
+            xml *= escape(v)
+        end
+
+        # Close </tag>...
+        if n != :text
+            xml *= "</$n>"
+        end
+    end
+
+    xml
+end

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -1,0 +1,27 @@
+# Indexable Collection support
+
+
+function Base.getindex(x::XMLElement, tag::AbstractString)
+    l = get_elements_by_tagname(x, tag)
+    if isempty(l)
+        return nothing
+    end
+    if isempty(child_elements(l[1]))
+        l = [strip(content(i)) for i in l]
+    end
+    return length(l) == 1 ? l[1] : l
+end
+
+Base.getindex(x::XMLElement, name::Symbol) = attribute(x, string(name))
+
+function Base.get(x::XMLElement, tag, default)
+    r = getindex(x, tag)
+    r != nothing ? r : default
+end
+
+Base.haskey(x::XMLElement, tag) = getindex(x, tag) != nothing
+
+
+Base.getindex(x::XMLDocument, tag) = getindex(root(x), tag)
+Base.haskey(x::XMLDocument, tag) = haskey(root(x), tag)
+Base.get(x::XMLDocument, tag, default) = get(root(x), tag, default)

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -28,15 +28,22 @@ Base.haskey(x::XMLDocument, tag) = haskey(root(x), tag)
 Base.get(x::XMLDocument, tag, default) = get(root(x), tag, default)
 
 
+
+
+if Pkg.installed("DataStructures") != nothing
+    eval(Expr(:using,:DataStructures))
+    const default_dict_type = OrderedDict
+else
+    const default_dict_type = Dict
+end
+
 # Convert XMLDocument to OrderedDict...
 
-using DataStructures
-
-function xml_dict(x::AbstractString, dict_type::Type=OrderedDict; options...)
+function xml_dict(x::AbstractString, dict_type::Type=default_dict_type; options...)
     xml_dict(parse_string(x), dict_type; options...)
 end
 
-function xml_dict(x::XMLDocument, dict_type::Type=OrderedDict; options...)
+function xml_dict(x::XMLDocument, dict_type::Type=default_dict_type; options...)
     r = dict_type()
     r[:version] = version(x)
     if encoding(x) != nothing

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -345,3 +345,11 @@ function set_attributes(x::XMLElement; attrs...)
         set_attribute(x, string(nam), string(val))
     end
 end
+
+
+function escape(s::AbstractString)
+    p = ccall((:xmlEncodeEntitiesReentrant,libxml2), Xstr, (Xptr, Cstring), C_NULL, s)
+    (p != C_NULL ? _xcopystr(p) : "")::AbstractString
+end
+
+

--- a/test/getindex.jl
+++ b/test/getindex.jl
@@ -1,4 +1,12 @@
-xml = """
+function xdict(xml)
+    for (n,v) in xml_dict(xml; strip_text=true)
+        if !isa(n, Symbol)
+            return v
+        end
+    end
+end
+
+xml1 = """
 <CreateQueueResponse>
     <CreateQueueResult>
         <QueueUrl>
@@ -13,11 +21,15 @@ xml = """
 </CreateQueueResponse>
 """
 
-@test parse_string(xml)["CreateQueueResult"]["QueueUrl"] ==
+@test parse_string(xml1)["CreateQueueResult"]["QueueUrl"] ==
+      "http://queue.amazonaws.com/123456789012/testQueue"
+
+@test xdict(xml1)["CreateQueueResult"]["QueueUrl"] ==
       "http://queue.amazonaws.com/123456789012/testQueue"
 
 
-xml = """
+
+xml2 = """
 <GetUserResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <GetUserResult>
     <User>
@@ -33,10 +45,14 @@ xml = """
 </GetUserResponse>
 """
 
-@test parse_string(xml)["GetUserResult"]["User"]["Arn"] == "arn:aws:iam::012541411202:root"
+@test parse_string(xml2)["GetUserResult"]["User"]["Arn"] == 
+      "arn:aws:iam::012541411202:root"
+
+@test xdict(xml2)["GetUserResult"]["User"]["Arn"] == 
+      "arn:aws:iam::012541411202:root"
 
 
-xml = """
+xml3 = """
 <GetQueueAttributesResponse>
   <GetQueueAttributesResult>
     <Attribute>
@@ -82,14 +98,20 @@ xml = """
 </GetQueueAttributesResponse>
 """
 
-xml = parse_string(xml)
+xml = parse_string(xml3)
+d = [a["Name"] => a["Value"] for a in xml["GetQueueAttributesResult"]["Attribute"]]
+
+@test d["MessageRetentionPeriod"] == "345600"
+@test d["CreatedTimestamp"] == "1286771522"
+
+xml = xdict(xml3)
 d = [a["Name"] => a["Value"] for a in xml["GetQueueAttributesResult"]["Attribute"]]
 
 @test d["MessageRetentionPeriod"] == "345600"
 @test d["CreatedTimestamp"] == "1286771522"
 
 
-xml = """
+xml4 = """
 <?xml version="1.0" encoding="UTF-8"?>
 <ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
   <Owner>
@@ -109,10 +131,11 @@ xml = """
 </ListAllMyBucketsResult>
 """
 
-@test [b["Name"] for b in parse_string(xml)["Buckets"]["Bucket"]] == ["quotes", "samples"]
+@test [b["Name"] for b in parse_string(xml4)["Buckets"]["Bucket"]] == ["quotes", "samples"]
 
+@test [b["Name"] for b in xdict(xml4)["Buckets"]["Bucket"]] == ["quotes", "samples"]
 
-xml = """
+xml5 = """
 <ListDomainsResponse>
   <ListDomainsResult foobar="Hello">
     <DomainName>Domain1</DomainName>
@@ -126,4 +149,67 @@ xml = """
 </ListDomainsResponse>
 """
 
-@test parse_string(xml)["ListDomainsResult"][:foobar] == "Hello"
+@test parse_string(xml5)["ListDomainsResult"][:foobar] == "Hello"
+
+@test xdict(xml5)["ListDomainsResult"][:foobar] == "Hello"
+
+
+xml6 = """
+<?xml version="1.0" encoding="UTF-8"?>
+<bookstore brand="amazon">
+  <book category="COOKING" tag="first">
+    <title lang="en">
+        Everyday Italian
+    </title>
+    <author>Giada De Laurentiis</author>
+    <year>2005</year>
+    <price>30.00</price>
+    <extract copyright="NA">The <b>bold</b> word is <b><i>not</i></b> <i>italic</i>.</extract>
+  </book>
+  <book category="CHILDREN">
+    <title lang="en">Harry Potter</title>
+    <author>J K. Rowling</author>
+    <year>2005</year>
+    <price>29.99</price>
+    <foo><![CDATA[<sender>John Smith</sender>]]></foo>
+    <extract>Click <a href="foobar.com">right <b>here</b></a> for foobar.</extract>
+  </book>
+  <metadata>
+       <foo>hello!</foo>
+  </metadata>
+</bookstore>
+"""
+
+function normalise_xml(xml)
+    o,i,p = readandwrite(
+        `bash -c 'xmllint --format --nocdata - | sed s/\ xmlns=\".*\"//g' `)
+    write(i, xml)
+    close(i)
+    readall(o)
+end
+
+using JSON
+
+for xml in [xml1, xml2, xml3, xml4, xml5, xml6]
+
+    if normalise_xml(xml) != normalise_xml(dict_xml(xml_dict(xml)))
+
+        println(normalise_xml(dict_xml(xml_dict(xml))))
+
+
+        open(`xargs -0 node -e "var o; o = JSON.parse(process.argv[1]);
+                                var u; u = require('util'); 
+                                console.log(u.inspect(o, {depth:null, colors: true}));"
+              `, "w", STDOUT) do io
+            write(io, json(xml_dict(xml)))
+        end
+
+        open("/tmp/a", "w") do f write(f, normalise_xml(xml)) end
+        open("/tmp/b", "w") do f write(f, normalise_xml(dict_xml(xml_dict(xml)))) end
+        run(`opendiff /tmp/a /tmp/b`)
+    end
+
+
+    @test normalise_xml(xml) == normalise_xml(dict_xml(xml_dict(xml)))
+
+end

--- a/test/getindex.jl
+++ b/test/getindex.jl
@@ -1,0 +1,129 @@
+xml = """
+<CreateQueueResponse>
+    <CreateQueueResult>
+        <QueueUrl>
+            http://queue.amazonaws.com/123456789012/testQueue
+        </QueueUrl>
+    </CreateQueueResult>
+    <ResponseMetadata>
+        <RequestId>
+            7a62c49f-347e-4fc4-9331-6e8e7a96aa73
+        </RequestId>
+    </ResponseMetadata>
+</CreateQueueResponse>
+"""
+
+@test parse_string(xml)["CreateQueueResult"]["QueueUrl"] ==
+      "http://queue.amazonaws.com/123456789012/testQueue"
+
+
+xml = """
+<GetUserResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <GetUserResult>
+    <User>
+      <PasswordLastUsed>2015-12-23T22:45:36Z</PasswordLastUsed>
+      <Arn>arn:aws:iam::012541411202:root</Arn>
+      <UserId>012541411202</UserId>
+      <CreateDate>2015-09-15T01:07:23Z</CreateDate>
+    </User>
+  </GetUserResult>
+  <ResponseMetadata>
+    <RequestId>837446c9-abaf-11e5-9f63-65ae4344bd73</RequestId>
+  </ResponseMetadata>
+</GetUserResponse>
+"""
+
+@test parse_string(xml)["GetUserResult"]["User"]["Arn"] == "arn:aws:iam::012541411202:root"
+
+
+xml = """
+<GetQueueAttributesResponse>
+  <GetQueueAttributesResult>
+    <Attribute>
+      <Name>ReceiveMessageWaitTimeSeconds</Name>
+      <Value>2</Value>
+    </Attribute>
+    <Attribute>
+      <Name>VisibilityTimeout</Name>
+      <Value>30</Value>
+    </Attribute>
+    <Attribute>
+      <Name>ApproximateNumberOfMessages</Name>
+      <Value>0</Value>
+    </Attribute>
+    <Attribute>
+      <Name>ApproximateNumberOfMessagesNotVisible</Name>
+      <Value>0</Value>
+    </Attribute>
+    <Attribute>
+      <Name>CreatedTimestamp</Name>
+      <Value>1286771522</Value>
+    </Attribute>
+    <Attribute>
+      <Name>LastModifiedTimestamp</Name>
+      <Value>1286771522</Value>
+    </Attribute>
+    <Attribute>
+      <Name>QueueArn</Name>
+      <Value>arn:aws:sqs:us-east-1:123456789012:qfoo</Value>
+    </Attribute>
+    <Attribute>
+      <Name>MaximumMessageSize</Name>
+      <Value>8192</Value>
+    </Attribute>
+    <Attribute>
+      <Name>MessageRetentionPeriod</Name>
+      <Value>345600</Value>
+    </Attribute>
+  </GetQueueAttributesResult>
+  <ResponseMetadata>
+    <RequestId>1ea71be5-b5a2-4f9d-b85a-945d8d08cd0b</RequestId>
+  </ResponseMetadata>
+</GetQueueAttributesResponse>
+"""
+
+xml = parse_string(xml)
+d = [a["Name"] => a["Value"] for a in xml["GetQueueAttributesResult"]["Attribute"]]
+
+@test d["MessageRetentionPeriod"] == "345600"
+@test d["CreatedTimestamp"] == "1286771522"
+
+
+xml = """
+<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
+  <Owner>
+    <ID>bcaf1ffd86f461ca5fb16fd081034f</ID>
+    <DisplayName>webfile</DisplayName>
+  </Owner>
+  <Buckets>
+    <Bucket>
+      <Name>quotes</Name>
+      <CreationDate>2006-02-03T16:45:09.000Z</CreationDate>
+    </Bucket>
+    <Bucket>
+      <Name>samples</Name>
+      <CreationDate>2006-02-03T16:41:58.000Z</CreationDate>
+    </Bucket>
+  </Buckets>
+</ListAllMyBucketsResult>
+"""
+
+@test [b["Name"] for b in parse_string(xml)["Buckets"]["Bucket"]] == ["quotes", "samples"]
+
+
+xml = """
+<ListDomainsResponse>
+  <ListDomainsResult foobar="Hello">
+    <DomainName>Domain1</DomainName>
+    <DomainName>Domain2</DomainName>
+    <NextToken>TWV0ZXJpbmdUZXN0RG9tYWluMS0yMDA3MDYwMTE2NTY=</NextToken>
+  </ListDomainsResult>
+  <ResponseMetadata>
+    <RequestId>eb13162f-1b95-4511-8b12-489b86acfd28</RequestId>
+    <BoxUsage>0.0000219907</BoxUsage>
+  </ResponseMetadata>
+</ListDomainsResponse>
+"""
+
+@test parse_string(xml)["ListDomainsResult"][:foobar] == "Hello"

--- a/test/getindex.jl
+++ b/test/getindex.jl
@@ -153,6 +153,8 @@ xml5 = """
 
 @test xdict(xml5)["ListDomainsResult"][:foobar] == "Hello"
 
+if Pkg.installed("DataStructures") != nothing
+
 
 xml6 = """
 <?xml version="1.0" encoding="UTF-8"?>
@@ -188,7 +190,7 @@ function normalise_xml(xml)
     readall(o)
 end
 
-using JSON
+eval(Expr(:using, :JSON))
 
 for xml in [xml1, xml2, xml3, xml4, xml5, xml6]
 
@@ -213,3 +215,6 @@ for xml in [xml1, xml2, xml3, xml4, xml5, xml6]
     @test normalise_xml(xml) == normalise_xml(dict_xml(xml_dict(xml)))
 
 end
+
+
+end #if Pkg.installed("DataStructures") != nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-tests = ["parse", "create", "cdata"]
+tests = ["parse", "create", "cdata", "getindex"]
 
 for t in tests
     fpath = "$t.jl"


### PR DESCRIPTION
Adds support for Indexable syntax, e.g. `xml[tag1][tag2][tag3]`. See full examples in README.md.

Also adds convenience constructors:
```julia
parse_string(s::Array{UInt8,1}) = parse_string(bytestring(s))
XMLDocument(xml) = parse_string(xml)
XML(xml) = XMLDocument(xml)
``` 

The aim is to have a quick way to extract particular tags from web service responses like this:

```julia
xml = """
<?xml version="1.0" encoding="UTF-8"?>
<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
  <Owner>
    <ID>bcaf1ffd86f461ca5fb16fd081034f</ID>
    <DisplayName>webfile</DisplayName>
  </Owner>
  <Buckets>
    <Bucket>
      <Name>quotes</Name>
      <CreationDate>2006-02-03T16:45:09.000Z</CreationDate>
    </Bucket>
    <Bucket>
      <Name>samples</Name>
      <CreationDate>2006-02-03T16:41:58.000Z</CreationDate>
    </Bucket>
  </Buckets>
</ListAllMyBucketsResult>
"""

@test XML(xml)["Buckets"]["Bucket"]["Name"] == ["quotes", "samples"]
```