### PR TITLE
Don't export parse_string and parse_file

### DIFF
--- a/src/LightXML.jl
+++ b/src/LightXML.jl
@@ -24,7 +24,7 @@ export
 
     # document
     XMLDocument, version, encoding, compression, standalone, root,
-    parse_file, parse_string, save_file, set_root, create_root
+    save_file, set_root, create_root
 
 typealias Xchar UInt8
 typealias Xstr Ptr{Xchar}


### PR DESCRIPTION
`parse_string(::AbstractString)` and `parse_file(::AbstractString)` are too general to be exported.