### PR TITLE
Add iteratorsize

### DIFF
--- a/src/LightXML.jl
+++ b/src/LightXML.jl
@@ -4,6 +4,18 @@ module LightXML
 
 using Compat
 
+# iteratorsize is new in 0.5, declare it here for older versions. However,
+# we do not actually support calling these, since the traits are not defined
+if VERSION < v"0.5.0-dev+3305"
+    function iteratorsize(v)
+        error("Do not call this on older versions")
+    end
+else
+    import Base: iteratorsize, SizeUnknown, IsInfinite, HasLength
+end
+
+
+
 const libxml2 = @windows? Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libxml2-2") : "libxml2"
 
 export

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -98,7 +98,7 @@ end
 Base.start(it::XMLAttrIter) = it.p
 Base.done(it::XMLAttrIter, p::Xptr) = (p == C_NULL)
 Base.next(it::XMLAttrIter, p::Xptr) = (a = XMLAttr(p); (a, a._struct.next))
-iteratorsize(::Type{XMLAttrIter})=SizeUnknown()
+iteratorsize(::Type{XMLAttrIter}) = SizeUnknown()
 
 #######################################
 #
@@ -163,7 +163,7 @@ end
 Base.start(it::XMLNodeIter) = it.p
 Base.done(it::XMLNodeIter, p::Xptr) = (p == C_NULL)
 Base.next(it::XMLNodeIter, p::Xptr) = (nd = XMLNode(p); (nd, nd._struct.next))
-iteratorsize(::Type{XMLNodeIter})=SizeUnknown()
+iteratorsize(::Type{XMLNodeIter}) = SizeUnknown()
 
 child_nodes(nd::XMLNode) = XMLNodeIter(nd._struct.children)
 
@@ -264,7 +264,7 @@ end
 Base.start(it::XMLElementIter) = ccall((:xmlFirstElementChild,libxml2), Xptr, (Xptr,), it.parent_ptr)
 Base.done(it::XMLElementIter, p::Xptr) = (p == C_NULL)
 Base.next(it::XMLElementIter, p::Xptr) = (XMLElement(p), ccall((:xmlNextElementSibling,libxml2), Xptr, (Xptr,), p))
-iteratorsize(::Type{XMLElementIter})=SizeUnknown()
+iteratorsize(::Type{XMLElementIter}) = SizeUnknown()
 
 child_elements(x::XMLElement) = XMLElementIter(x.node.ptr)
 

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -98,7 +98,7 @@ end
 Base.start(it::XMLAttrIter) = it.p
 Base.done(it::XMLAttrIter, p::Xptr) = (p == C_NULL)
 Base.next(it::XMLAttrIter, p::Xptr) = (a = XMLAttr(p); (a, a._struct.next))
-
+iteratorsize(::Type{XMLAttrIter})=SizeUnknown()
 
 #######################################
 #
@@ -163,6 +163,7 @@ end
 Base.start(it::XMLNodeIter) = it.p
 Base.done(it::XMLNodeIter, p::Xptr) = (p == C_NULL)
 Base.next(it::XMLNodeIter, p::Xptr) = (nd = XMLNode(p); (nd, nd._struct.next))
+iteratorsize(::Type{XMLNodeIter})=SizeUnknown()
 
 child_nodes(nd::XMLNode) = XMLNodeIter(nd._struct.children)
 
@@ -263,6 +264,7 @@ end
 Base.start(it::XMLElementIter) = ccall((:xmlFirstElementChild,libxml2), Xptr, (Xptr,), it.parent_ptr)
 Base.done(it::XMLElementIter, p::Xptr) = (p == C_NULL)
 Base.next(it::XMLElementIter, p::Xptr) = (XMLElement(p), ccall((:xmlNextElementSibling,libxml2), Xptr, (Xptr,), p))
+iteratorsize(::Type{XMLElementIter})=SizeUnknown()
 
 child_elements(x::XMLElement) = XMLElementIter(x.node.ptr)
 


### PR DESCRIPTION
This should fix it with v0.5 of Julia. Re: all iterators are broken.
To be honest I haven't tested this version directly, am doing a quick commit and am relying on TravisCI to test it. If this doesn't CI I'll do a more careful branch and fix.

This problem is referenced in https://github.com/JuliaLang/LightXML.jl/pull/46#issuecomment-219366412

See: https://github.com/JuliaLang/julia/issues/15977 and the linked documentation gist
